### PR TITLE
Update browser_client.dart

### DIFF
--- a/lib/src/http/src/browser_client.dart
+++ b/lib/src/http/src/browser_client.dart
@@ -60,8 +60,12 @@ class BrowserClient extends BaseClient {
       ..open(request.method, '${request.url}', true)
       ..responseType = 'arraybuffer'
       ..withCredentials = withCredentials;
-    request.headers.forEach(xhr.setRequestHeader);
-
+    
+    //request.headers.forEach(xhr.setRequestHeader);
+    for (MapEntry<String, String> entry in request.headers.entries) {
+      xhr.setRequestHeader(entry.key, entry.value);
+    }
+    
     var completer = Completer<StreamedResponse>();
 
     unawaited(xhr.onLoad.first.then((_) {


### PR DESCRIPTION
The reason for the change is that on Flutter Web I had an error
I only changed one line in lib/src/http/src/browser_client.dart and used an explicit for loop instead a forEach
for (MapEntry<String, String> entry in request.headers.entries) {
      xhr.setRequestHeader(entry.key, entry.value);
    }
Thank you for your nice library. It was useful